### PR TITLE
docs: align OpenAPI & contracts

### DIFF
--- a/docs/api-contracts-target.md
+++ b/docs/api-contracts-target.md
@@ -2,16 +2,17 @@
 
 Target-state contracts derived from current implementation and product goals, emphasizing backward-compatible evolution with explicit migrations.
 
-## Validation Findings (2025-12-19)
-- **GET /api/tickets**: Current handler returns `{ tickets }` scoped by requester/organization with no pagination, filtering, or sorting, and always 200.—«…F:src/app/api/tickets/route.ts‘«·L16-L38—«≈ Target contract adds pagination/filtering and metadata.
-- **POST /api/tickets**: Implementation validates title/description/priority/category, computes SLA due dates, writes an audit event, and returns 200 without idempotency headers.—«…F:src/app/api/tickets/route.ts‘«·L40-L89—«≈ Target requires `Idempotency-Key` and may change status code to 201.
-- **PATCH/PUT /api/tickets/{id}**: Supports status/priority/assignee updates with role-based guards; rejects missing status for requesters, invalid assignee/team, or no changes; no `If-Match`/etag logic present (header ignored).—«…F:src/app/api/tickets/[id]/route.ts‘«·L8-L197—«≈ Target adds optimistic locking and 412 handling.
+## Validation Findings (2025-12-20)
+- **GET /api/tickets**: Current handler returns `{ tickets }` scoped by requester/organization with no pagination, filtering, or sorting, and always 200.„ÄêF:src/app/api/tickets/route.ts‚Ä†L16-L38„Äë Target contract adds pagination/filtering and metadata.
+- **POST /api/tickets**: Implementation validates title/description/priority/category, computes SLA due dates, ignores any `tags` field, writes an audit event, and returns 200 without idempotency headers.„ÄêF:src/app/api/tickets/route.ts‚Ä†L9-L14„Äë„ÄêF:src/app/api/tickets/route.ts‚Ä†L52-L88„Äë Target requires `Idempotency-Key`, tag assignment, and may change status code to 201.
+- **PATCH/PUT /api/tickets/{id}**: Supports status/priority/assignee updates with role-based guards; rejects missing status for requesters, invalid assignee/team, or no changes; no `If-Match`/etag logic present (header ignored).„ÄêF:src/app/api/tickets/[id]/route.ts‚Ä†L8-L197„Äë Target adds optimistic locking and 412 handling.
 - **GET /api/tickets/{id}**: No handler exists; target endpoint remains planned.
-- **POST /api/tickets/{id}/comments**: Validates `bodyMd` (min 1), optional `isInternal`, enforces role checks but does not verify organization scope, stamps `firstResponseAt` for first public agent comment, and returns 200; no idempotency or listing endpoint implemented.—«…F:src/app/api/tickets/[id]/comments/route.ts‘«·L7-L59—«≈ Target adds org scoping, optional idempotency, and comment listing.
-- **Error envelope**: AS-IS handlers return `{ error: string | ZodFlattenedError }` directly instead of the structured `ErrorResponse` documented in contracts.—«…F:src/app/api/tickets/route.ts‘«·L17-L38—«≈—«…F:src/app/api/tickets/[id]/route.ts‘«·L25-L110—«≈ Target keeps the normalized envelope requirement.
-- **GET /api/tickets response shape**: AS-IS payloads include expanded `requester`, `assigneeUser`, and `assigneeTeam` objects from Prisma includes, which are not modeled in the target schema.—«…F:src/app/api/tickets/route.ts‘«·L20-L38—«≈ Target keeps the flattened Ticket representation and plans to scope fields.
-- **Attachments schema gap**: Prisma model lacks `status`/`url` fields assumed by target attachment contract, and no handlers exist yet.—«…F:prisma/schema.prisma‘«·L122-L140—«≈ Target keeps the richer attachment contract pending implementation.
+- **POST /api/tickets/{id}/comments**: Validates `bodyMd` (min 1), optional `isInternal`, enforces role checks but does not verify organization scope, stamps `firstResponseAt` for first public agent comment, and returns 200; no idempotency or listing endpoint implemented.„ÄêF:src/app/api/tickets/[id]/comments/route.ts‚Ä†L7-L59„Äë Target adds org scoping, optional idempotency, and comment listing.
+- **Error envelope**: AS-IS handlers return `{ error: string | ZodFlattenedError }` directly instead of the structured `ErrorResponse` documented in contracts.„ÄêF:src/app/api/tickets/route.ts‚Ä†L17-L38„Äë„ÄêF:src/app/api/tickets/[id]/route.ts‚Ä†L25-L110„Äë Target keeps the normalized envelope requirement.
+- **GET /api/tickets response shape**: AS-IS payloads include expanded `requester`, `assigneeUser`, and `assigneeTeam` objects from Prisma includes and omit `tags`, which are not modeled/populated per the target schema.„ÄêF:src/app/api/tickets/route.ts‚Ä†L20-L38„Äë Target keeps the flattened Ticket representation, tag array, and plans to scope fields.
+- **Attachments schema gap**: Prisma model lacks `status`/`url` fields assumed by target attachment contract, and no handlers exist yet.„ÄêF:prisma/schema.prisma‚Ä†L122-L140„Äë Target keeps the richer attachment contract pending implementation.
 - **Attachments/Webhooks**: No handlers implemented; models exist only in Prisma. Target design stays marked as planned until storage/scan/webhook plumbing exists.
+
 
 ## Goals
 - Stabilize ticketing APIs with pagination, idempotency, and org-safe access controls.
@@ -27,7 +28,7 @@ Target-state contracts derived from current implementation and product goals, em
 ## Endpoint Contracts (Target)
 ### `GET /api/tickets`
 - **Query**: `status`, `priority`, `q` (search `title` + `descriptionMd`), `limit` (default 20, max 100), `offset` (default 0), `sort` (e.g., `createdAt:desc`).
-- **AuthZ**: Requester ‘ÊÂ own tickets; agent/admin ‘ÊÂ organization tickets.
+- **AuthZ**: Requester -> own tickets; agent/admin -> organization tickets.
 - **Response**: `{ tickets: Ticket[], page: { limit, offset, total } }`.
 
 ### `POST /api/tickets`
@@ -55,7 +56,7 @@ Target-state contracts derived from current implementation and product goals, em
 - **Visibility**: Requesters see only public comments; agents/admins see all.
 
 ### `POST /api/tickets/{id}/attachments`
-- **Flow**: Accept metadata `{ fileName, mimeType, sizeBytes }`; validate size (‘Î•25MB) and MIME allowlist. Return signed upload URL plus attachment record in `PENDING` state.
+- **Flow**: Accept metadata `{ fileName, mimeType, sizeBytes }`; validate size (<=25MB) and MIME allowlist. Return signed upload URL plus attachment record in `PENDING` state.
 - **Access**: Organization match required; requester allowed when ticket owner; agents/admins allowed for org.
 - **Scan**: Require asynchronous AV scan hook; mark attachment status accordingly. Access to downloads only after `CLEAN`.
 
@@ -82,13 +83,13 @@ Target-state contracts derived from current implementation and product goals, em
 - Replay with same key returns original 2xx response; conflicting body returns 409 `CONFLICT_IDEMPOTENCY_BODY_MISMATCH`.
 
 ## Concurrency & Locking
-- Ticket resource returns `etag` (hash of `updatedAt`). `PATCH`/`PUT` must include `If-Match`; mismatch ‘ÊÂ 412 with error code `PRECONDITION_FAILED`.
+- Ticket resource returns `etag` (hash of `updatedAt`). `PATCH`/`PUT` must include `If-Match`; mismatch -> 412 with error code `PRECONDITION_FAILED`.
 - Comment/attachment creation unaffected by etag but should reference latest ticket state when needed.
 
 ## Attachments Contract
 - Max size 25MB; allowed MIME types: common images, PDFs, text logs, zip; block executables.
 - Storage via signed URLs (provider-agnostic). Upload URL TTL 15 minutes; download URL TTL 5 minutes.
-- Virus scanning webhook updates status `PENDING` ‘ÊÂ `CLEAN` or `REJECTED`; downloads forbidden unless `CLEAN`.
+- Virus scanning webhook updates status `PENDING` -> `CLEAN` or `REJECTED`; downloads forbidden unless `CLEAN`.
 
 ## Webhooks/Events (Future)
 - Outbound webhooks optional per organization with HMAC signature (`X-Webhook-Signature`) and retry backoff (up to 3 attempts). Event types: `ticket.created`, `ticket.updated`, `comment.created`, `attachment.created`, `sla.breached`.
@@ -118,7 +119,7 @@ Target-state contracts derived from current implementation and product goals, em
 22. Rate limit defaults (100 requests/5m per user) with 429 error; configurable. *(Design choice)*
 23. Responses use ISO timestamps and UUIDs; enums uppercase per Prisma. *(AS-IS evidence)*
 24. Pagination metadata returned with list endpoints (`page.total` optional when counting). *(Design choice)*
-25. Sorting via `field:direction`; unsupported fields ‘ÊÂ 400. *(Design choice)*
+25. Sorting via `field:direction`; unsupported fields -> 400. *(Design choice)*
 26. Requesters may view their ticket comments/attachments only; agents/admins view org-wide. *(Design choice informed by current role checks)*
 27. Audit events include actorId and before/after change set. *(AS-IS evidence for change set; design for exposure)*
 28. Admin CRUD endpoints scoped to organization, audited, and rate-limited. *(Design choice)*

--- a/docs/openapi-validation.md
+++ b/docs/openapi-validation.md
@@ -11,33 +11,43 @@
 
 ## Mismatches and actions
 1. **Idempotency header documented as required but unused in code**
-   - Evidence: Ticket creation handler never reads `Idempotency-Key`; it simply parses JSON and creates the ticket.ÑÇÉF:src/app/api/tickets/route.tsÔÇáL40-L89ÑÇÅ
-   - Action: OpenAPI keeps `Idempotency-Key` optional with AS-IS note; target contract continues to require it for future enforcement.ÑÇÉF:docs/openapi.yamlÔÇáL312-L352ÑÇÅÑÇÉF:docs/api-contracts-target.mdÔÇáL7-L12ÑÇÅ
+   - Evidence: Ticket creation handler never reads `Idempotency-Key`; it simply parses JSON and creates the ticket.ã€F:src/app/api/tickets/route.tsâ€ L40-L88ã€‘
+   - Action: OpenAPI keeps `Idempotency-Key` optional with AS-IS note; target contract continues to require it for future enforcement.ã€F:docs/openapi.yamlâ€ L345-L359ã€‘ã€F:docs/api-contracts-target.mdâ€ L6-L7ã€‘
 
 2. **If-Match requirement not implemented**
-   - Evidence: PATCH/PUT ticket handler performs role/validation checks without reading `If-Match` or etags.ÑÇÉF:src/app/api/tickets/[id]/route.tsÔÇáL8-L197ÑÇÅ
-   - Action: OpenAPI headers remain optional with explicit AS-IS caveat; target contract keeps optimistic locking as a future change.ÑÇÉF:docs/openapi.yamlÔÇáL374-L454ÑÇÅÑÇÉF:docs/api-contracts-target.mdÔÇáL7-L11ÑÇÅ
+   - Evidence: PATCH/PUT ticket handler performs role/validation checks without reading `If-Match` or etags.ã€F:src/app/api/tickets/[id]/route.tsâ€ L8-L197ã€‘
+   - Action: OpenAPI headers remain optional with explicit AS-IS caveat; target contract keeps optimistic locking as a future change.ã€F:docs/openapi.yamlâ€ L414-L457ã€‘ã€F:docs/api-contracts-target.mdâ€ L8-L11ã€‘
 
 3. **Comment endpoint lacks organization scoping**
-   - Evidence: Comment creation checks requester/agent roles but never verifies `organizationId` against the ticket, allowing cross-org access if ticket ID is known.ÑÇÉF:src/app/api/tickets/[id]/comments/route.tsÔÇáL17-L51ÑÇÅ
-   - Action: OpenAPI description calls out missing org enforcement; target contract explicitly adds org scoping and idempotency as future work.ÑÇÉF:docs/openapi.yamlÔÇáL507-L561ÑÇÅÑÇÉF:docs/api-contracts-target.mdÔÇáL12-L12ÑÇÅ
+   - Evidence: Comment creation checks requester/agent roles but never verifies `organizationId` against the ticket, allowing cross-org access if ticket ID is known.ã€F:src/app/api/tickets/[id]/comments/route.tsâ€ L16-L39ã€‘
+   - Action: OpenAPI description calls out missing org enforcement; target contract explicitly adds org scoping and idempotency as future work.ã€F:docs/openapi.yamlâ€ L511-L561ã€‘ã€F:docs/api-contracts-target.mdâ€ L10-L10ã€‘
 
 4. **Error envelope not aligned with code**
-   - Evidence: Handlers return `{ error: string | ZodFlattenedError }` instead of the documented `ErrorResponse` shape.ÑÇÉF:src/app/api/tickets/route.tsÔÇáL17-L38ÑÇÅÑÇÉF:src/app/api/tickets/[id]/route.tsÔÇáL25-L110ÑÇÅ
-   - Action: Shared OpenAPI responses now note the AS-IS error payloads while retaining the normalized target envelope requirement in contracts.ÑÇÉF:docs/openapi.yamlÔÇáL57-L71ÑÇÅÑÇÉF:docs/api-contracts-target.mdÔÇáL7-L12ÑÇÅ
+   - Evidence: Handlers return `{ error: string | ZodFlattenedError }` instead of the documented `ErrorResponse` shape.ã€F:src/app/api/tickets/route.tsâ€ L17-L38ã€‘ã€F:src/app/api/tickets/[id]/route.tsâ€ L25-L110ã€‘
+   - Action: Shared OpenAPI responses note the AS-IS error payloads while retaining the normalized target envelope requirement in contracts.ã€F:docs/openapi.yamlâ€ L63-L76ã€‘ã€F:docs/api-contracts-target.mdâ€ L11-L11ã€‘
 
 5. **GET /api/tickets payload shape diverges from schema**
-   - Evidence: Handler includes full `requester`, `assigneeUser`, and `assigneeTeam` objects via Prisma `include`, which are not modeled in the Ticket schema.ÑÇÉF:src/app/api/tickets/route.tsÔÇáL20-L38ÑÇÅ
-   - Action: OpenAPI description now flags the expanded payload as AS-IS; target contract keeps the flattened Ticket representation and scoping requirement.ÑÇÉF:docs/openapi.yamlÔÇáL275-L303ÑÇÅÑÇÉF:docs/api-contracts-target.mdÔÇáL7-L12ÑÇÅ
+   - Evidence: Handler includes expanded `requester`, `assigneeUser`, and `assigneeTeam` objects and omits `tags`, which differs from the documented Ticket schema.ã€F:src/app/api/tickets/route.tsâ€ L20-L38ã€‘
+   - Action: OpenAPI description flags the expanded/omitted fields as AS-IS; target contract keeps the flattened Ticket representation with tags.ã€F:docs/openapi.yamlâ€ L295-L303ã€‘ã€F:docs/api-contracts-target.mdâ€ L12-L13ã€‘
 
-6. **Attachment contract exceeds current data model**
-   - Evidence: Prisma attachment model lacks `status` and `url` fields assumed by the target Attachment schema; no handlers exist.ÑÇÉF:prisma/schema.prismaÔÇáL122-L140ÑÇÅ
-   - Action: OpenAPI Attachment schema now explicitly notes it is target-only until storage/scan support exists; target contract notes the pending work.ÑÇÉF:docs/openapi.yamlÔÇáL110-L137ÑÇÅÑÇÉF:docs/api-contracts-target.mdÔÇáL13-L14ÑÇÅ
+6. **Ticket creation ignores `tags`**
+   - Evidence: Create schema omits `tags`, and the handler never persists or returns them.ã€F:src/app/api/tickets/route.tsâ€ L9-L88ã€‘
+   - Action: OpenAPI marks `tags` as target-only in the schema and POST description; target contract retains tag assignment as a requirement.ã€F:docs/openapi.yamlâ€ L169-L190ã€‘ã€F:docs/openapi.yamlâ€ L345-L359ã€‘ã€F:docs/api-contracts-target.mdâ€ L6-L7ã€‘
+
+7. **Attachment contract exceeds current data model**
+   - Evidence: Prisma attachment model lacks `status` and `url` fields assumed by the target Attachment schema; no handlers exist.ã€F:prisma/schema.prismaâ€ L122-L140ã€‘
+   - Action: OpenAPI Attachment schema notes target-only fields until storage/scan support exists; target contract notes the pending work.ã€F:docs/openapi.yamlâ€ L239-L270ã€‘ã€F:docs/api-contracts-target.mdâ€ L13-L14ã€‘
+
+8. **GET /api/tickets/{id} OpenAPI previously advertised pagination params**
+   - Evidence: There is no GET handler, and the planned single-resource endpoint should not accept `limit`/`offset`.ã€F:src/app/api/tickets/[id]/route.tsâ€ L1-L197ã€‘
+   - Action: Removed `limit`/`offset` query parameters from the OpenAPI spec to align with target behavior and current code reality (endpoint still planned).ã€F:docs/openapi.yamlâ€ L380-L410ã€‘
 
 ## Remaining verification steps
 - Decide idempotency storage and TTL strategy before enforcing headers.
 - Define etag format (`updatedAt` hash or version) and 412 error payload before implementing optimistic locking.
 - Add organization checks to comment handler and implement listing endpoint to meet documented contract.
 - Normalize error responses to the documented `ErrorResponse` envelope or update the contract if the simple `{ error }` shape is retained.
+- Implement tag parsing/persistence on ticket create and return tags in ticket list responses to match the target schema.
+- Implement `GET /api/tickets/{id}` with org-scoped detail response per target contract.
 - Confirm whether ticket list responses should include requester/assignee summaries or be flattened to IDs, then align schema and handlers accordingly.
 - Extend Prisma Attachment model (status/url) and implement upload/download handlers or revise the target attachment contract.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -186,6 +186,7 @@ components:
           nullable: true
         tags:
           type: array
+          description: Target-only tag assignment; AS-IS handler ignores this field and does not persist tags.
           items:
             $ref: '#/components/schemas/TagRef'
     TicketUpdate:
@@ -298,7 +299,7 @@ paths:
       description: |
         AS-IS implementation returns `{ tickets }` without pagination, filtering, or sorting and scopes results by role/organization.
         Target behavior adds `limit`/`offset`/`sort` and optional `status`/`priority`/`q` filters plus pagination metadata.
-        AS-IS payload includes expanded `requester`, `assigneeUser`, and `assigneeTeam` objects not modeled in the target schema.
+        AS-IS payload includes expanded `requester`, `assigneeUser`, and `assigneeTeam` objects and omits `tags`, which are not modeled/populated in the target schema.
       x-implementation-status: "as-is (pagination/filtering not yet implemented)"
       security:
         - cookieAuth: []
@@ -344,8 +345,9 @@ paths:
     post:
       summary: Create ticket
       description: |
-        AS-IS returns 200 with `{ ticket }` and does not enforce idempotency. Target behavior should return 201, require an
-        `Idempotency-Key`, and include pagination-friendly metadata fields such as `etag`.
+        AS-IS returns 200 with `{ ticket }`, ignores any provided `tags`, and does not enforce idempotency. Target behavior should
+        return 201, require an `Idempotency-Key`, include pagination-friendly metadata fields such as `etag`, and support tag
+        assignment.
       x-implementation-status: "as-is (idempotency + 201 response pending)"
       security:
         - cookieAuth: []
@@ -392,8 +394,6 @@ paths:
           required: true
           schema:
             type: string
-        - $ref: '#/components/parameters/Limit'
-        - $ref: '#/components/parameters/Offset'
       responses:
         '200':
           description: Ticket detail


### PR DESCRIPTION
Aligns OpenAPI/contracts with repo truth. Auto-merge if OK.