### PR TITLE
MVP: SLA admin UI (closes #63)

### DIFF
--- a/docs/sla-admin-ui-notes.md
+++ b/docs/sla-admin-ui-notes.md
@@ -1,0 +1,14 @@
+# SLA admin UI (Issue #63)
+
+## Manual checklist
+- Sign in as admin; open `/app/admin/sla-policies`.
+- Ensure list renders existing policies (from seed) with priority, category (or "Wszystkie kategorie"), and hour values.
+- Create policy with valid data and optional category; see success toast and list update.
+- Attempt invalid input (empty priority or 0 hours) and see validation error (inline/toast).
+- Edit an existing policy: change hours, save, see row update.
+- Delete a policy and confirm it disappears from the list.
+- Confirm non-admin user is redirected away from the page.
+
+## Test notes
+- Client validation mirrored with `slaPolicySchema`; unit test `tests/sla-admin-validation.test.ts` covers happy + invalid numeric path.
+- API wiring uses `/api/admin/sla-policies` and `/api/admin/sla-policies/{id}` (must be available from #62).

--- a/src/app/app/admin/sla-policies/page.tsx
+++ b/src/app/app/admin/sla-policies/page.tsx
@@ -1,0 +1,60 @@
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { SlaPoliciesManager } from "./sla-policies-manager";
+
+export default async function SlaPoliciesPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect("/login");
+  }
+  if (session.user.role !== "ADMIN") {
+    redirect("/app");
+  }
+
+  const [policies, categories] = await Promise.all([
+    prisma.slaPolicy.findMany({
+      where: { organizationId: session.user.organizationId ?? "" },
+      orderBy: [{ priority: "asc" }, { categoryId: "asc" }],
+      include: { category: { select: { id: true, name: true } } },
+    }),
+    prisma.category.findMany({
+      where: { organizationId: session.user.organizationId ?? "" },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  const mappedPolicies = policies.map((p) => ({
+    id: p.id,
+    priority: p.priority,
+    categoryId: p.categoryId,
+    categoryName: p.category?.name ?? null,
+    firstResponseHours: p.firstResponseHours,
+    resolveHours: p.resolveHours,
+  }));
+
+  const mappedCategories = categories.map((c) => ({
+    id: c.id,
+    name: c.name,
+  }));
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      <div>
+        <p className="text-xs uppercase text-slate-500">Admin</p>
+        <h1 className="text-2xl font-semibold text-slate-900">
+          Polityki SLA
+        </h1>
+        <p className="text-sm text-slate-600">
+          Zarządzaj czasami pierwszej reakcji i rozwiązania dla priorytetów i
+          kategorii.
+        </p>
+      </div>
+      <SlaPoliciesManager
+        initialPolicies={mappedPolicies}
+        categories={mappedCategories}
+      />
+    </div>
+  );
+}

--- a/src/app/app/admin/sla-policies/sla-policies-manager.tsx
+++ b/src/app/app/admin/sla-policies/sla-policies-manager.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { TicketPriority } from "@prisma/client";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { slaPolicySchema, validateSlaInput } from "./validation";
+
+type SlaPolicyRow = {
+  id: string;
+  priority: TicketPriority;
+  categoryId: string | null;
+  categoryName: string | null;
+  firstResponseHours: number;
+  resolveHours: number;
+};
+
+type CategoryOption = { id: string; name: string };
+
+type FormState = {
+  priority: TicketPriority;
+  categoryId: string;
+  firstResponseHours: string;
+  resolveHours: string;
+};
+
+type EditingState = {
+  [id: string]: FormState & { saving: boolean; error?: string };
+};
+
+type Props = {
+  initialPolicies: SlaPolicyRow[];
+  categories: CategoryOption[];
+};
+
+const defaultForm = (categories: CategoryOption[]): FormState => ({
+  priority: TicketPriority.NISKI,
+  categoryId: categories[0]?.id ?? "",
+  firstResponseHours: "24",
+  resolveHours: "72",
+});
+
+export function SlaPoliciesManager({ initialPolicies, categories }: Props) {
+  const [policies, setPolicies] = useState<SlaPolicyRow[]>(initialPolicies);
+  const [form, setForm] = useState<FormState>(defaultForm(categories));
+  const [loading, setLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<EditingState>({});
+
+  const categoriesWithNone = useMemo(
+    () => [{ id: "", name: "Wszystkie kategorie" }, ...categories],
+    [categories],
+  );
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    const parsed = validateSlaInput({
+      priority: form.priority,
+      categoryId: form.categoryId || null,
+      firstResponseHours: form.firstResponseHours,
+      resolveHours: form.resolveHours,
+    });
+    if (!parsed.success) {
+      const message =
+        parsed.error.flatten().formErrors[0] ?? "Wprowadź poprawne wartości.";
+      setFormError(message);
+      toast.error(message);
+      return;
+    }
+
+    setLoading(true);
+    const res = await fetch("/api/admin/sla-policies", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed.data),
+    });
+    setLoading(false);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      const message = typeof body?.error === "string" ? body.error : "Nie udało się dodać polityki.";
+      setFormError(message);
+      toast.error(message);
+      return;
+    }
+
+    const { policy } = await res.json();
+    setPolicies((prev) => [
+      ...prev,
+      {
+        id: policy.id,
+        priority: policy.priority,
+        categoryId: policy.categoryId,
+        categoryName: policy.category?.name ?? null,
+        firstResponseHours: policy.firstResponseHours,
+        resolveHours: policy.resolveHours,
+      },
+    ]);
+    setForm(defaultForm(categories));
+    toast.success("Polityka dodana.");
+  };
+
+  const startEdit = (p: SlaPolicyRow) => {
+    setEditing((prev) => ({
+      ...prev,
+      [p.id]: {
+        priority: p.priority,
+        categoryId: p.categoryId ?? "",
+        firstResponseHours: String(p.firstResponseHours),
+        resolveHours: String(p.resolveHours),
+        saving: false,
+      },
+    }));
+  };
+
+  const cancelEdit = (id: string) => {
+    setEditing((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  };
+
+  const saveEdit = async (id: string) => {
+    const state = editing[id];
+    if (!state) return;
+    const parsed = validateSlaInput({
+      priority: state.priority,
+      categoryId: state.categoryId || null,
+      firstResponseHours: state.firstResponseHours,
+      resolveHours: state.resolveHours,
+    });
+    if (!parsed.success) {
+      toast.error(parsed.error.flatten().formErrors[0] ?? "Błąd walidacji.");
+      return;
+    }
+
+    setEditing((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], saving: true, error: undefined },
+    }));
+
+    const res = await fetch(`/api/admin/sla-policies/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed.data),
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      const message = body?.error ?? "Nie udało się zapisać zmian.";
+      setEditing((prev) => ({
+        ...prev,
+        [id]: { ...prev[id], saving: false, error: message },
+      }));
+      toast.error(message);
+      return;
+    }
+
+    const { policy } = await res.json();
+    setPolicies((prev) =>
+      prev.map((p) =>
+        p.id === id
+          ? {
+              id: policy.id,
+              priority: policy.priority,
+              categoryId: policy.categoryId,
+              categoryName: policy.category?.name ?? null,
+              firstResponseHours: policy.firstResponseHours,
+              resolveHours: policy.resolveHours,
+            }
+          : p
+      )
+    );
+    setEditing((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    toast.success("Zapisano zmiany.");
+  };
+
+  const deletePolicy = async (id: string) => {
+    setEditing((prev) => ({
+      ...prev,
+      [id]: { ...(prev[id] ?? defaultForm(categories)), saving: true },
+    }));
+    const res = await fetch(`/api/admin/sla-policies/${id}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      toast.error(body?.error ?? "Nie udało się usunąć polityki.");
+      setEditing((prev) => ({
+        ...prev,
+        [id]: { ...(prev[id] ?? defaultForm(categories)), saving: false },
+      }));
+      return;
+    }
+    setPolicies((prev) => prev.filter((p) => p.id !== id));
+    setEditing((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    toast.success("Polityka usunięta.");
+  };
+
+  const priorities = Object.values(TicketPriority);
+
+  return (
+    <div className="space-y-6">
+      <form className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm" onSubmit={handleCreate}>
+        <h2 className="text-lg font-semibold text-slate-900">Dodaj politykę SLA</h2>
+        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-1">
+            <label className="text-sm text-slate-700">Priorytet</label>
+            <select
+              className="rounded-lg border border-slate-300 px-3 py-2"
+              value={form.priority}
+              onChange={(e) => setForm((prev) => ({ ...prev, priority: e.target.value as TicketPriority }))}
+              disabled={loading}
+            >
+              {priorities.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm text-slate-700">Kategoria (opcjonalnie)</label>
+            <select
+              className="rounded-lg border border-slate-300 px-3 py-2"
+              value={form.categoryId}
+              onChange={(e) =>
+                setForm((prev) => ({
+                  ...prev,
+                  categoryId: e.target.value,
+                }))
+              }
+              disabled={loading || categoriesWithNone.length === 0}
+            >
+              {categoriesWithNone.map((cat) => (
+                <option key={cat.id} value={cat.id}>
+                  {cat.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm text-slate-700">Czas pierwszej reakcji (h)</label>
+            <input
+              type="number"
+              min={1}
+              className="rounded-lg border border-slate-300 px-3 py-2"
+              value={form.firstResponseHours}
+              onChange={(e) => setForm((prev) => ({ ...prev, firstResponseHours: e.target.value }))}
+              disabled={loading}
+            />
+          </div>
+          <div className="grid gap-1">
+            <label className="text-sm text-slate-700">Czas rozwiązania (h)</label>
+            <input
+              type="number"
+              min={1}
+              className="rounded-lg border border-slate-300 px-3 py-2"
+              value={form.resolveHours}
+              onChange={(e) => setForm((prev) => ({ ...prev, resolveHours: e.target.value }))}
+              disabled={loading}
+            />
+          </div>
+        </div>
+        {formError && <p className="mt-2 text-xs text-red-600">{formError}</p>}
+        <div className="mt-3 flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-lg bg-sky-600 px-4 py-2 text-white font-semibold hover:bg-sky-700 disabled:opacity-50"
+          >
+            {loading ? "Zapisywanie..." : "Dodaj politykę"}
+          </button>
+          <p className="text-xs text-slate-500">
+            Walidacja: priorytet wymagany, czasy &gt; 0, kategoria musi należeć do organizacji.
+          </p>
+        </div>
+      </form>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Istniejące polityki</h2>
+          <span className="text-xs text-slate-500">{policies.length} pozycji</span>
+        </div>
+        {policies.length === 0 ? (
+          <p className="mt-3 text-sm text-slate-500">Brak polityk SLA.</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {policies.map((p) => {
+              const edit = editing[p.id];
+              return (
+                <div
+                  key={p.id}
+                  className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 shadow-sm"
+                >
+                  {!edit && (
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-slate-800">
+                          {p.priority} • {p.categoryName ?? "Wszystkie kategorie"}
+                        </p>
+                        <p className="text-xs text-slate-600">
+                          Pierwsza reakcja: {p.firstResponseHours}h • Rozwiązanie: {p.resolveHours}h
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => startEdit(p)}
+                          className="text-xs font-semibold text-sky-700 underline"
+                        >
+                          Edytuj
+                        </button>
+                        <button
+                          onClick={() => deletePolicy(p.id)}
+                          className="text-xs font-semibold text-red-700 underline"
+                        >
+                          Usuń
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                  {edit && (
+                    <div className="space-y-2">
+                      <div className="grid gap-2 sm:grid-cols-2">
+                        <div className="grid gap-1">
+                          <label className="text-xs text-slate-700">Priorytet</label>
+                          <select
+                            className="rounded-lg border border-slate-300 px-2 py-1 text-sm"
+                            value={edit.priority}
+                            onChange={(e) =>
+                              setEditing((prev) => ({
+                                ...prev,
+                                [p.id]: { ...prev[p.id], priority: e.target.value as TicketPriority },
+                              }))
+                            }
+                            disabled={edit.saving}
+                          >
+                            {priorities.map((prio) => (
+                              <option key={prio} value={prio}>
+                                {prio}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="grid gap-1">
+                          <label className="text-xs text-slate-700">Kategoria</label>
+                          <select
+                            className="rounded-lg border border-slate-300 px-2 py-1 text-sm"
+                            value={edit.categoryId}
+                            onChange={(e) =>
+                              setEditing((prev) => ({
+                                ...prev,
+                                [p.id]: { ...prev[p.id], categoryId: e.target.value },
+                              }))
+                            }
+                            disabled={edit.saving}
+                          >
+                            {categoriesWithNone.map((cat) => (
+                              <option key={cat.id} value={cat.id}>
+                                {cat.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="grid gap-1">
+                          <label className="text-xs text-slate-700">Pierwsza reakcja (h)</label>
+                          <input
+                            type="number"
+                            min={1}
+                            className="rounded-lg border border-slate-300 px-2 py-1 text-sm"
+                            value={edit.firstResponseHours}
+                            onChange={(e) =>
+                              setEditing((prev) => ({
+                                ...prev,
+                                [p.id]: { ...prev[p.id], firstResponseHours: e.target.value },
+                              }))
+                            }
+                            disabled={edit.saving}
+                          />
+                        </div>
+                        <div className="grid gap-1">
+                          <label className="text-xs text-slate-700">Rozwiązanie (h)</label>
+                          <input
+                            type="number"
+                            min={1}
+                            className="rounded-lg border border-slate-300 px-2 py-1 text-sm"
+                            value={edit.resolveHours}
+                            onChange={(e) =>
+                              setEditing((prev) => ({
+                                ...prev,
+                                [p.id]: { ...prev[p.id], resolveHours: e.target.value },
+                              }))
+                            }
+                            disabled={edit.saving}
+                          />
+                        </div>
+                      </div>
+                      {edit.error && <p className="text-xs text-red-600">{edit.error}</p>}
+                      <div className="flex items-center gap-3">
+                        <button
+                          onClick={() => saveEdit(p.id)}
+                          className="rounded-lg bg-sky-600 px-3 py-1 text-sm font-semibold text-white disabled:opacity-50"
+                          disabled={edit.saving}
+                        >
+                          {edit.saving ? "Zapisywanie..." : "Zapisz"}
+                        </button>
+                        <button
+                          onClick={() => cancelEdit(p.id)}
+                          className="text-xs font-semibold text-slate-600 underline"
+                          disabled={edit.saving}
+                        >
+                          Anuluj
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/admin/sla-policies/validation.ts
+++ b/src/app/app/admin/sla-policies/validation.ts
@@ -1,0 +1,21 @@
+import { TicketPriority } from "@prisma/client";
+import { z } from "zod";
+
+export const slaPolicySchema = z.object({
+  priority: z.nativeEnum(TicketPriority, {
+    required_error: "Priorytet jest wymagany",
+  }),
+  categoryId: z.string().trim().min(1).optional().nullable(),
+  firstResponseHours: z.coerce.number().int().positive({
+    message: "Czas pierwszej reakcji musi być większy od 0",
+  }),
+  resolveHours: z.coerce.number().int().positive({
+    message: "Czas rozwiązania musi być większy od 0",
+  }),
+});
+
+export type SlaPolicyInput = z.infer<typeof slaPolicySchema>;
+
+export function validateSlaInput(input: Partial<SlaPolicyInput>) {
+  return slaPolicySchema.safeParse(input);
+}

--- a/src/lib/spam-guard.ts
+++ b/src/lib/spam-guard.ts
@@ -11,11 +11,13 @@ type Logger = {
 const lastCommentAt = new Map<string, number>();
 
 function getConfig() {
+  const explicit = process.env.SPAM_GUARD_ENABLED;
+  const allowInTest = explicit === "true";
   return {
-    // Disable spam guard in tests to avoid noisy timing-dependent failures.
+    // Default off in tests unless explicitly enabled via SPAM_GUARD_ENABLED=true.
     enabled:
-      process.env.NODE_ENV !== "test" &&
-      process.env.SPAM_GUARD_ENABLED !== "false",
+      (process.env.NODE_ENV !== "test" || allowInTest) &&
+      explicit !== "false",
     cooldownMs: Number.parseInt(process.env.SPAM_GUARD_COOLDOWN_MS ?? "10000", 10),
   };
 }

--- a/tests/sla-admin-validation.test.ts
+++ b/tests/sla-admin-validation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { TicketPriority } from "@prisma/client";
+import { validateSlaInput } from "@/app/app/admin/sla-policies/validation";
+
+describe("SLA policy client validation", () => {
+  it("accepts valid payload", () => {
+    const result = validateSlaInput({
+      priority: TicketPriority.SREDNI,
+      categoryId: null,
+      firstResponseHours: 8,
+      resolveHours: 24,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-positive numbers", () => {
+    const result = validateSlaInput({
+      priority: TicketPriority.SREDNI,
+      categoryId: null,
+      firstResponseHours: 0,
+      resolveHours: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #63

Summary:
- Admin UI for SLA policies (list/create/edit/delete) with client-side validation and loading/empty/error states
- Admin gate on page; uses categories taxonomy when present
- Added unit test for client validation and enabled spam guard in tests when explicitly set

Test proof:
- npm run lint
- npm test

Notes:
- Relies on /api/admin/sla-policies from #62; page redirects non-admins to /app