### PR TITLE
V1: SLA job schema/types (closes #105)

### DIFF
--- a/src/lib/sla-jobs.ts
+++ b/src/lib/sla-jobs.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "crypto";
+import { z } from "zod";
+
+export const slaJobTypeSchema = z.enum(["first-response", "resolve"]);
+
+export const slaJobPayloadSchema = z.object({
+  jobId: z.string().uuid(),
+  jobType: slaJobTypeSchema,
+  ticketId: z.string().uuid(),
+  organizationId: z.string(),
+  dueAt: z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "dueAt must be a valid ISO date string",
+  }),
+  priority: z.string(),
+  categoryId: z.string().uuid().nullable(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type SlaJobPayload = z.infer<typeof slaJobPayloadSchema>;
+
+export const slaJobResultSchema = z.object({
+  jobId: z.string().uuid(),
+  enqueued: z.boolean(),
+  deduped: z.boolean(),
+  jobType: slaJobTypeSchema,
+});
+
+export type SlaJobResult = z.infer<typeof slaJobResultSchema>;
+
+export async function enqueueSlaJob(
+  payload: SlaJobPayload
+): Promise<SlaJobResult> {
+  const parsed = slaJobPayloadSchema.parse(payload);
+  // stub: future implementation will push into queue/storage.
+  return {
+    jobId: parsed.jobId,
+    enqueued: true,
+    deduped: false,
+    jobType: parsed.jobType,
+  };
+}
+
+export function createSlaJobPayload(init: {
+  jobType: z.infer<typeof slaJobTypeSchema>;
+  ticketId: string;
+  organizationId: string;
+  dueAt: string | Date;
+  priority: string;
+  categoryId?: string | null;
+  metadata?: Record<string, unknown>;
+}): SlaJobPayload {
+  const payload: SlaJobPayload = {
+    jobId: randomUUID(),
+    jobType: init.jobType,
+    ticketId: init.ticketId,
+    organizationId: init.organizationId,
+    dueAt: typeof init.dueAt === "string" ? init.dueAt : init.dueAt.toISOString(),
+    priority: init.priority,
+    categoryId: init.categoryId ?? null,
+    metadata: init.metadata,
+  };
+
+  slaJobPayloadSchema.parse(payload);
+  return payload;
+}

--- a/tests/sla-jobs.test.ts
+++ b/tests/sla-jobs.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { createSlaJobPayload, enqueueSlaJob, slaJobPayloadSchema } from "@/lib/sla-jobs";
+
+describe("SLA job schema", () => {
+  it("validates a complete payload", () => {
+    const payload = createSlaJobPayload({
+      jobType: "first-response",
+      ticketId: "00000000-0000-0000-0000-000000000000",
+      organizationId: "org",
+      dueAt: new Date().toISOString(),
+      priority: "WYSOKI",
+    });
+
+    const parsed = slaJobPayloadSchema.parse(payload);
+    expect(parsed.jobType).toBe("first-response");
+    expect(parsed.jobId).toBeTruthy();
+  });
+
+  it("rejects invalid dueAt", () => {
+    expect(() =>
+      slaJobPayloadSchema.parse({
+        jobId: "22222222-2222-2222-2222-222222222222",
+        jobType: "resolve",
+      ticketId: "00000000-0000-0000-0000-000000000000",
+        organizationId: "org",
+        dueAt: "not-a-date",
+        priority: "NISKI",
+        categoryId: null,
+      })
+    ).toThrow();
+  });
+});
+
+describe("enqueue helper stub", () => {
+  it("returns queue result", async () => {
+    const payload = createSlaJobPayload({
+      jobType: "resolve",
+      ticketId: "00000000-0000-0000-0000-000000000000",
+      organizationId: "org",
+      dueAt: new Date().toISOString(),
+      priority: "SREDNI",
+    });
+
+    const result = await enqueueSlaJob(payload);
+    expect(result.enqueued).toBe(true);
+    expect(result.deduped).toBe(false);
+    expect(result.jobType).toBe("resolve");
+  });
+});


### PR DESCRIPTION
Closes #105\n\nSummary:\n- add SLA job payload schema + helper for first response/resolve jobs\n- provide enqueue stub that validates payload and returns job result\n- cover schema and enqueue logic with unit tests\n\nTest proof:\n- npm run lint\n- npm run test -- tests/sla-jobs.test.ts