### PR TITLE
V1: Schedule SLA jobs on ticket changes (closes #106)

### DIFF
--- a/src/app/api/tickets/[id]/route.ts
+++ b/src/app/api/tickets/[id]/route.ts
@@ -4,6 +4,7 @@ import { Prisma, TicketPriority, TicketStatus } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { scheduleSlaJobsForTicket } from "@/lib/sla-scheduler";
 
 const updateSchema = z
   .object({
@@ -192,6 +193,14 @@ async function updateTicket(
       },
     }),
   ]);
+
+  await scheduleSlaJobsForTicket({
+    id: updatedTicket.id,
+    organizationId: updatedTicket.organizationId,
+    priority: updatedTicket.priority,
+    firstResponseDue: updatedTicket.firstResponseDue,
+    resolveDue: updatedTicket.resolveDue,
+  });
 
   return NextResponse.json({ ticket: updatedTicket });
 }

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -6,6 +6,7 @@ import { sanitizeMarkdown } from "@/lib/sanitize";
 import { getTicketPage } from "@/lib/ticket-list";
 import { findSlaPolicyForTicket } from "@/lib/sla-policy";
 import { computeSlaDueDates } from "@/lib/sla-preview";
+import { scheduleSlaJobsForTicket } from "@/lib/sla-scheduler";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { TicketPriority, TicketStatus } from "@prisma/client";
@@ -128,6 +129,14 @@ export async function POST(req: Request) {
   logger.info("tickets.create.success", {
     ticketId: ticket.id,
     priority: ticket.priority,
+  });
+
+  await scheduleSlaJobsForTicket({
+    id: ticket.id,
+    organizationId: ticket.organizationId,
+    priority: ticket.priority,
+    firstResponseDue: ticket.firstResponseDue,
+    resolveDue: ticket.resolveDue,
   });
 
   return NextResponse.json({ ticket });

--- a/src/lib/sla-scheduler.ts
+++ b/src/lib/sla-scheduler.ts
@@ -1,0 +1,53 @@
+import { enqueueSlaJob, createSlaJobPayload, SlaJobResult } from "@/lib/sla-jobs";
+
+type DueField = {
+  jobType: "first-response" | "resolve";
+  dueAt: string | Date | null | undefined;
+};
+
+export type TicketSlaSchedule = {
+  id: string;
+  organizationId: string;
+  priority: string;
+  categoryId?: string | null;
+  firstResponseDue?: string | Date | null;
+  resolveDue?: string | Date | null;
+};
+
+function toIso(value: string | Date | null | undefined) {
+  if (!value) return null;
+  return typeof value === "string" ? value : value.toISOString();
+}
+
+export async function scheduleSlaJobsForTicket(ticket: TicketSlaSchedule): Promise<SlaJobResult[]> {
+  const dueFields: DueField[] = [
+    { jobType: "first-response", dueAt: ticket.firstResponseDue },
+    { jobType: "resolve", dueAt: ticket.resolveDue },
+  ];
+
+  const now = Date.now();
+  const results: SlaJobResult[] = [];
+
+  for (const field of dueFields) {
+    const dueIso = toIso(field.dueAt);
+    if (!dueIso) continue;
+    if (Date.parse(dueIso) <= now) continue;
+
+    const idempotencyKey = `sla:${ticket.id}:${field.jobType}:${dueIso}`;
+    const payload = createSlaJobPayload({
+      jobType: field.jobType,
+      ticketId: ticket.id,
+      organizationId: ticket.organizationId,
+      dueAt: dueIso,
+      priority: ticket.priority,
+      categoryId: ticket.categoryId ?? null,
+      metadata: { ticketId: ticket.id, jobType: field.jobType },
+      idempotencyKey,
+    });
+
+    const result = await enqueueSlaJob(payload);
+    results.push(result);
+  }
+
+  return results;
+}

--- a/tests/sla-jobs.test.ts
+++ b/tests/sla-jobs.test.ts
@@ -46,4 +46,21 @@ describe("enqueue helper stub", () => {
     expect(result.deduped).toBe(false);
     expect(result.jobType).toBe("resolve");
   });
+
+  it("dedupes on matching idempotency key", async () => {
+    const payload = createSlaJobPayload({
+      jobType: "resolve",
+      ticketId: "00000000-0000-0000-0000-000000000000",
+      organizationId: "org",
+      dueAt: new Date().toISOString(),
+      priority: "SREDNI",
+      idempotencyKey: "job-1",
+    });
+
+    const first = await enqueueSlaJob(payload);
+    const second = await enqueueSlaJob(payload);
+
+    expect(second.deduped).toBe(true);
+    expect(second.jobId).toBe(first.jobId);
+  });
 });

--- a/tests/sla-scheduler.test.ts
+++ b/tests/sla-scheduler.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { scheduleSlaJobsForTicket } from "@/lib/sla-scheduler";
+import { resetSlaJobDedupe } from "@/lib/sla-jobs";
+
+beforeEach(() => {
+  resetSlaJobDedupe();
+});
+
+describe("SLA scheduler", () => {
+  it("enqueues only future timers", async () => {
+    const ticket = {
+      id: "55555555-5555-5555-5555-555555555555",
+      organizationId: "org",
+      priority: "SREDNI",
+      firstResponseDue: new Date(Date.now() + 60000).toISOString(),
+      resolveDue: new Date(Date.now() - 60000).toISOString(),
+    };
+
+    const result = await scheduleSlaJobsForTicket(ticket);
+    expect(result).toHaveLength(1);
+    expect(result[0].jobType).toBe("first-response");
+  });
+
+  it("dedupes repeated schedules", async () => {
+    const ticket = {
+      id: "66666666-6666-6666-6666-666666666666",
+      organizationId: "org",
+      priority: "WYSOKI",
+      firstResponseDue: new Date(Date.now() + 60000).toISOString(),
+      resolveDue: null,
+    };
+
+    const first = await scheduleSlaJobsForTicket(ticket);
+    const second = await scheduleSlaJobsForTicket(ticket);
+
+    expect(first[0].deduped).toBe(false);
+    expect(second[0].deduped).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #106\n\nSummary:\n- enqueue SLA timer jobs on ticket create/update using the shared payload schema\n- skip past timers and encode dedupe key so repeated scheduling stays idempotent\n- cover scheduling behavior with unit tests\n\nTest proof:\n- npm run lint\n- npm run test -- tests/sla-jobs.test.ts tests/sla-scheduler.test.ts