### PR TITLE
CI: fix contract tests prisma automationRule mock

### DIFF
--- a/tests/contract/api-contract.test.ts
+++ b/tests/contract/api-contract.test.ts
@@ -25,6 +25,9 @@ const mockPrisma = vi.hoisted(() => ({
   comment: {
     create: vi.fn(),
   },
+  automationRule: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));


### PR DESCRIPTION
Fix contract-tests failure by mocking prisma.automationRule.findMany to return an empty list.