### PR TITLE
CI: guard automation rules evaluation when no rules

### DIFF
--- a/src/lib/automation-rules.ts
+++ b/src/lib/automation-rules.ts
@@ -146,6 +146,10 @@ export async function evaluateAutomationRules(
     },
   });
 
+  if (!Array.isArray(rules)) {
+    return;
+  }
+
   for (const rule of rules) {
     try {
       const trigger = validateTriggerConfig(rule.triggerConfig);


### PR DESCRIPTION
Fix CI contract-tests: ensure evaluateAutomationRules skips when mocked prisma returns non-array rules.