### PR TITLE
Fix: Resolve CI lint errors by replacing 'any' types with proper types

### DIFF
--- a/src/lib/email-adapter.ts
+++ b/src/lib/email-adapter.ts
@@ -11,13 +11,7 @@ export interface EmailAdapter {
 }
 
 export class EmailAdapterStub implements EmailAdapter {
-  async send(_params: {
-    to: string;
-    subject: string;
-    body?: string;
-    templateId?: string;
-    data?: Record<string, unknown>;
-  }): Promise<{ id: string; status: "sent" | "queued" }> {
+  async send(): Promise<{ id: string; status: "sent" | "queued" }> {
     // Stub implementation - does not send emails
     return {
       id: `email-${Date.now()}`,


### PR DESCRIPTION
Fixes CI lint check failures by replacing 'any' types with proper TypeScript types:

- Replace 'any' types with proper TypeScript types in automation rules API
- Fix NextAuth handler type casting  
- Update JSON field handling for Prisma
- Fix unused parameter warnings
- Remove unnecessary type assertions

All lint errors resolved, only warnings for intentionally unused parameters remain.