### PR TITLE
V3: Fix Prisma schema - add missing csatResponse relation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,7 @@ model Ticket {
   slaPauseTotalSeconds Int    @default(0)
   lastReopenedAt   DateTime?
   csatRequest      CsatRequest?
+  csatResponse     CsatResponse? @relation("TicketCsatResponse")
 
   @@index([organizationId, title, descriptionMd, category], name: "Ticket_search_idx")
 }


### PR DESCRIPTION
Adds missing csatResponse relation field to Ticket model. Fixes CI Prisma validation error.